### PR TITLE
- Changed uri template expansion value url encoding logic.

### DIFF
--- a/hal-tooling-core/README.md
+++ b/hal-tooling-core/README.md
@@ -13,7 +13,7 @@ Consists of types used to model [HAL](https://tools.ietf.org/html/draft-kelly-js
 <properties>
   ...
   <!-- Use the latest version whenever possible. -->
-  <hal-tooling.version>1.1.0</hal-tooling.version>
+  <hal-tooling.version>1.1.1</hal-tooling.version>
   ...
 </properties>
 

--- a/hal-tooling-core/pom.xml
+++ b/hal-tooling-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.codeframes</groupId>
         <artifactId>hal-tooling</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hal-tooling-core</artifactId>

--- a/hal-tooling-json/README.md
+++ b/hal-tooling-json/README.md
@@ -15,7 +15,7 @@ types ([hal-tooling-core](https://github.com/codeframes/hal-tooling/tree/master/
 <properties>
   ...
   <!-- Use the latest version whenever possible. -->
-  <hal-tooling.version>1.1.0</hal-tooling.version>
+  <hal-tooling.version>1.1.1</hal-tooling.version>
   ...
 </properties>
 

--- a/hal-tooling-json/pom.xml
+++ b/hal-tooling-json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.codeframes</groupId>
         <artifactId>hal-tooling</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hal-tooling-json</artifactId>

--- a/hal-tooling-link-bindings-jax-rs/README.md
+++ b/hal-tooling-link-bindings-jax-rs/README.md
@@ -14,7 +14,7 @@ adds support for **JAX-RS 2.0** Resource Method Binding.
 <properties>
   ...
   <!-- Use the latest version whenever possible. -->
-  <hal-tooling.version>1.1.0</hal-tooling.version>
+  <hal-tooling.version>1.1.1</hal-tooling.version>
   ...
 </properties>
 

--- a/hal-tooling-link-bindings-jax-rs/pom.xml
+++ b/hal-tooling-link-bindings-jax-rs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.codeframes</groupId>
         <artifactId>hal-tooling</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hal-tooling-link-bindings-jax-rs</artifactId>

--- a/hal-tooling-link-bindings/README.md
+++ b/hal-tooling-link-bindings/README.md
@@ -14,7 +14,7 @@ A Module for injecting Link dependencies into `com.github.codeframes.hal.tooling
 <properties>
   ...
   <!-- Use the latest version whenever possible. -->
-  <hal-tooling.version>1.1.0</hal-tooling.version>
+  <hal-tooling.version>1.1.1</hal-tooling.version>
   ...
 </properties>
 

--- a/hal-tooling-link-bindings/pom.xml
+++ b/hal-tooling-link-bindings/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.codeframes</groupId>
         <artifactId>hal-tooling</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hal-tooling-link-bindings</artifactId>

--- a/hal-tooling-link-bindings/src/main/java/com/github/codeframes/hal/tooling/link/bindings/inject/RootBeanLinkSetter.java
+++ b/hal-tooling-link-bindings/src/main/java/com/github/codeframes/hal/tooling/link/bindings/inject/RootBeanLinkSetter.java
@@ -34,8 +34,8 @@ class RootBeanLinkSetter implements BeanLinkSetter {
     @Override
     public void setLinks(Object entity, LinkContext linkContext) {
         final LinkProvider linkProvider = new LinkProvider(linkContext.forBean(entity), curieDescriptors);
-        for (LinkSetter linkFieldSetter : linkSetters) {
-            linkFieldSetter.setLinks(entity, linkProvider);
+        for (LinkSetter linkSetter : linkSetters) {
+            linkSetter.setLinks(entity, linkProvider);
         }
     }
 }

--- a/hal-tooling-test/README.md
+++ b/hal-tooling-test/README.md
@@ -14,7 +14,7 @@ extensions used for testing RESTful API's.
 <properties>
   ...
   <!-- Use the latest version whenever possible. -->
-  <hal-tooling.version>1.1.0</hal-tooling.version>
+  <hal-tooling.version>1.1.1</hal-tooling.version>
   ...
 </properties>
 

--- a/hal-tooling-test/pom.xml
+++ b/hal-tooling-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.codeframes</groupId>
         <artifactId>hal-tooling</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hal-tooling-test</artifactId>

--- a/hal-tooling-test/src/main/groovy/com/github/codeframes/hal/tooling/test/json/JSON.groovy
+++ b/hal-tooling-test/src/main/groovy/com/github/codeframes/hal/tooling/test/json/JSON.groovy
@@ -15,6 +15,8 @@
  */
 package com.github.codeframes.hal.tooling.test.json
 
+import org.codehaus.groovy.runtime.GStringImpl
+
 /**
  * Encapsulates a String or GString as a JSON type specifically for use with
  * {@link com.github.codeframes.hal.tooling.test.http.HttpClient} to help aid assertions. Also adds asType support to
@@ -33,8 +35,8 @@ class JSON {
             }
         }
 
-        def gStringAsType = GString.metaClass.asType
-        GString.metaClass.asType = { Class target ->
+        def gStringAsType = GStringImpl.metaClass.asType
+        GStringImpl.metaClass.asType = { Class target ->
             if (JSON == target) {
                 return new JSON((GString) delegate)
             } else {

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.github.codeframes</groupId>
     <artifactId>hal-tooling</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>HAL Tooling</name>
     <description>Parent pom for HAL Tooling project modules.</description>


### PR DESCRIPTION
Will now only encode values that do not solely consist of safe and/or reserved characters.

 - Safe characters:  Alphanumerics [0-9a-zA-Z], special characters $-_.+!*'(),
 - Reserved characters:   ;/?:@=&
- Replaced  `GString.metaClass.asType` with `GStringImpl.metaClass.asType` used for JSON  type coercion due to the latter not working reliably